### PR TITLE
Update `Irc\Client` constructor behaviour.

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -59,12 +59,20 @@ class          Client
     /**
      * Constructor.
      *
-     * @param   \Hoa\Socket\Client  $client    Client.
+     * @param   string|\Hoa\Socket\Client  $client    Client.
      * @return  void
      * @throws  \Hoa\Socket\Exception
      */
-    public function __construct(Socket\Client $client)
+    public function __construct($client)
     {
+        if( is_string($client) ) {
+            $client = new Socket\Client($client);
+        } elseif( !($client instanceof Socket\Client) ) {
+            throw new Exception(
+                'Client must be a valid Hoa\Socket\Client instance'
+            );
+        }
+
         parent::__construct($client);
         $this->getConnection()->setNodeName('\Hoa\Irc\Node');
         $this->setListener(

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ $uri    = 'tcp://chat.freenode.org:6667';
 $client = new Hoa\Irc\Client(new Hoa\Socket\Client($uri));
 ```
 
+It's also possible to use the socket URI directly in the constructor:
+
+```php
+$client = new Hoa\Irc\Client('tcp://chat.freenode.org:6667');
+```
+
 Then, we attach our listeners. When the connexion will be opened, we will join a
 channel, for example `#hoaproject` with the `Gordon` username:
 


### PR DESCRIPTION
Previously the constructors must be called with an instance of `Socket\Client` as the first parameter. Now it can handle string too.