### PR TITLE
Add `irc` transport wrapper.

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -38,7 +38,7 @@ namespace Hoa\Irc;
 
 use Hoa\Event;
 use Hoa\Exception;
-use Hoa\Socket;
+use Hoa\Socket as HoaSocket;
 
 /**
  * Class \Hoa\Irc\Client.
@@ -49,7 +49,7 @@ use Hoa\Socket;
  * @license    New BSD License
  */
 class          Client
-    extends    Socket\Connection\Handler
+    extends    HoaSocket\Connection\Handler
     implements Event\Listenable
 {
     use Event\Listens;
@@ -60,10 +60,9 @@ class          Client
      * Constructor.
      *
      * @param   \Hoa\Socket\Client  $client    Client.
-     * @return  void
      * @throws  \Hoa\Socket\Exception
      */
-    public function __construct(Socket\Client $client)
+    public function __construct(HoaSocket\Client $client)
     {
         parent::__construct($client);
         $this->getConnection()->setNodeName('\Hoa\Irc\Node');
@@ -95,7 +94,7 @@ class          Client
      * @return  void
      * @throws  \Hoa\Irc\Exception
      */
-    protected function _run(Socket\Node $node)
+    protected function _run(HoaSocket\Node $node)
     {
         if (false === $node->hasJoined()) {
             $node->setJoined(true);
@@ -227,7 +226,7 @@ class          Client
      * @param   \Hoa\Socket\Node  $node       Node.
      * @return  \Closure
      */
-    protected function _send($message, Socket\Node $node)
+    protected function _send($message, HoaSocket\Node $node)
     {
         return $node->getConnection()->writeAll($message . CRLF);
     }

--- a/Socket.php
+++ b/Socket.php
@@ -39,107 +39,39 @@ namespace Hoa\Irc;
 use Hoa\Socket as HoaSocket;
 
 /**
- * Class \Hoa\Irc\Node.
+ * Class \Hoa\Irc\Socket.
  *
- * Describe a IRC node.
+ * Irc specific socket extension.
  *
  * @copyright  Copyright © 2007-2016 Hoa community
  * @license    New BSD License
  */
-class Node extends HoaSocket\Node
+class Socket extends HoaSocket
 {
     /**
-     * Whether this is basically the first message.
+     * Factory to create a valid instance from the given URI
      *
-     * @var bool
+     * @param string $socketUri URI of the socket to connect to.
+     * @return void
      */
-    protected $_joined   = false;
-
-    /**
-     * Username.
-     *
-     * @var string
-     */
-    protected $_username = null;
-
-    /**
-     * Channel.
-     *
-     * @var string
-     */
-    protected $_channel  = null;
-
-
-
-    /**
-     * Whether the client has already joined a channel or not.
-     *
-     * @param   bool  $joined    Joined or not.
-     * @return  bool
-     */
-    public function setJoined($joined)
+    public static function transportFactory($socketUri)
     {
-        $old           = $this->_joined;
-        $this->_joined = $joined;
+        $parsed = parse_url($socketUri);
+        if (false === $parsed) {
+            throw new Exception(
+                'URL %s seems syntactically invalid.',
+                0,
+                $socketUri
+            );
+        }
 
-        return $old;
-    }
+        $port = isset($parsed['port'])?$parsed['port']:6667;
 
-    /**
-     * Whether the client has already joined a channel or not.
-     *
-     * @return  bool
-     */
-    public function hasJoined()
-    {
-        return $this->_joined;
-    }
-
-    /**
-     * Set username.
-     *
-     * @param   string  $username    Username.
-     * @return  string
-     */
-    public function setUsername($username)
-    {
-        $old             = $this->_username;
-        $this->_username = $username;
-
-        return $old;
-    }
-
-    /**
-     * Get username.
-     *
-     * @return  string
-     */
-    public function getUsername()
-    {
-        return $this->_username;
-    }
-
-    /**
-     * Set current channel.
-     *
-     * @param   string  $channel    Channel.
-     * @return  string
-     */
-    public function setChannel($channel)
-    {
-        $old            = $this->_channel;
-        $this->_channel = $channel;
-
-        return $old;
-    }
-
-    /**
-     * Get current channel.
-     *
-     * @return  string
-     */
-    public function getChannel()
-    {
-        return $this->_channel;
+        return new static('tcp://' . $parsed['host'] . ':' . $port);
     }
 }
+
+/**
+ * Register socket wrappers
+ */
+HoaSocket\Transport::register('irc', ['Hoa\Irc\Socket', 'transportFactory']);

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "autoload": {
         "psr-4": {
             "Hoa\\Irc\\": "."
-        }
+        },
+        "files": [ "Socket.php" ]
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
A specific `Hoa\Irc\Socket` definition has been added which contains the transport factory method.

The `Socket` is autoloaded through composer.json. The `Client` and `Node` have been updated to avoid class collision with `Hoa\Socket`.

The method used here is the same than in `Hoa\Websocket`. I checked that the default port for `irc` is 6667 so this is the fallback one.