### PR TITLE
Typo in `composer.json` fix #23

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "hoa/consistency": "~1.0",
         "hoa/event"      : "~1.0",
         "hoa/exception"  : "~1.0",
-        "hoa/socket"     : "~0.0"
+        "hoa/socket"     : "~1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As explained in #22 by @shulard, there's a typo in the `composer.json`, we should use `hoa/socket : ~1.0`.